### PR TITLE
fix(main): allow a custom theme to be specified in options.theme

### DIFF
--- a/lua/drop/config.lua
+++ b/lua/drop/config.lua
@@ -115,6 +115,9 @@ function M.get_theme()
   local Util = require("drop.util")
   local themes = require("drop.themes")
   if M.options.theme ~= "auto" then
+    if type(M.options.theme) ~= "string" then
+      return M.options.theme
+    end
     return themes[M.options.theme]
   end
 


### PR DESCRIPTION
## Description

Before some recent updates, I was able to use

```lua
require('drop').setup({
    theme = {
        symbols = {
            -- my symbols here
        },
        colors = {
            -- my colors here
        },
    },
})
```

Now with the preset themes, this no longer works. Also, it is specified that `options.theme` can be a `DropTheme` in addition to a string. However, if it's not a string then it breaks.

This PR allows non-string values to be set for `options.theme`.