### PR TITLE
Remove border around created window

### DIFF
--- a/lua/drop/drop.lua
+++ b/lua/drop/drop.lua
@@ -114,7 +114,9 @@ function M.show()
       })
     end,
   })
-  vim.wo[M.win].winhighlight = "NormalFloat:Drop"
+  -- Force transparent background by setting Normal to a highlight group with no background
+  vim.api.nvim_set_hl(0, "DropNvimTransparent", { bg = "NONE" })
+  vim.wo[M.win].winhighlight = "NormalFloat:DropNvimTransparent,Normal:DropNvimTransparent"
   vim.wo[M.win].winblend = config.options.winblend
   M.ticks = 0
   M.timer = vim.loop.new_timer()

--- a/lua/drop/drop.lua
+++ b/lua/drop/drop.lua
@@ -96,6 +96,7 @@ function M.show()
     zindex = 10,
     style = "minimal",
     noautocmd = true,
+    border = "none",
   })
   vim.api.nvim_create_autocmd("VimResized", {
     callback = function()
@@ -109,6 +110,7 @@ function M.show()
         col = 0,
         width = vim.go.columns,
         height = vim.go.lines,
+        border = "none",
       })
     end,
   })


### PR DESCRIPTION
## Description

This change removes the border around the floating window that is used to create the animations.


## Related Issue(s)

  - Fixes #42. 

## Screenshots

<img width="1913" height="774" alt="image" src="https://github.com/user-attachments/assets/a3f2ab7b-a397-4a27-99c7-fc555a8317ee" />

(border in this screenshot is coming from my hyprland around the terminal also the gray bar at the top is the winbar which i style with a special color)

